### PR TITLE
Transformers type now uses simplified contract.

### DIFF
--- a/lib/match.ts
+++ b/lib/match.ts
@@ -1,4 +1,3 @@
-import * as skhema from 'skhema';
 import { Contract } from './contract';
 import { TransformerSet } from './transformer';
 
@@ -8,17 +7,15 @@ export function matchTransformers(
 	currentContract: Contract<any>,
 ) {
 	return transformers.filter((transformer) => {
-		if (!transformer.data.filter) {
+		if (!transformer.data.transforms) {
 			return false;
 		}
-		const matchesCurrent = skhema.isValid(
-			transformer.data.filter,
-			currentContract,
+		const matchesCurrent = transformer.data.transforms.includes(
+			currentContract.type,
 		);
-		const matchesPrevious = skhema.isValid(
-			transformer.data.filter,
-			previousContract || {},
-		);
+		const matchesPrevious = previousContract
+			? transformer.data.transforms.includes(previousContract.type)
+			: false;
 		return matchesCurrent && !matchesPrevious;
 	});
 }

--- a/lib/transformer.ts
+++ b/lib/transformer.ts
@@ -1,4 +1,3 @@
-import { JSONSchema6 } from 'json-schema';
 import { Contract, ContractSource, ContractType } from './contract';
 
 export type TransformerSet = TransformerContract[];
@@ -7,9 +6,8 @@ export interface TransformerType extends ContractType {
 	type: 'transformer';
 	typeVersion: '1.0.0';
 	data: {
-		filter: JSONSchema6;
-		autoFinalize: boolean;
-		encryptedSecrets?: any;
+		creates?: string[];
+		transforms: string[];
 	};
 }
 

--- a/test/integration/registry.spec.ts
+++ b/test/integration/registry.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import {ArtifactType, loadImage, logger, Registry} from '../../lib';
+import { ArtifactType, loadImage, logger, Registry } from '../../lib';
 
 jest.setTimeout(60 * 60 * 1000);
 

--- a/test/unit/match.spec.ts
+++ b/test/unit/match.spec.ts
@@ -1,24 +1,10 @@
 import { randomUUID } from 'crypto';
 import { createContract, matchTransformers, TransformerType } from '../../lib';
-import { JSONSchema6 } from 'json-schema';
 
 describe('Transformers', function () {
 	describe('matchTransformers()', function () {
 		// TODO: semver match version
-		const filterEqualsInput: JSONSchema6 = {
-			type: 'object',
-			required: ['type'],
-			properties: {
-				type: { const: 'source' },
-			},
-		};
-		const filterNotEqualsInput: JSONSchema6 = {
-			type: 'object',
-			required: ['type'],
-			properties: {
-				type: { const: 'else' },
-			},
-		};
+
 		const matchTransformer = createContract<TransformerType>({
 			type: 'transformer',
 			name: 'match-me',
@@ -26,8 +12,7 @@ describe('Transformers', function () {
 			version: randomUUID(),
 			typeVersion: '1.0.0',
 			data: {
-				autoFinalize: false,
-				filter: filterEqualsInput,
+				transforms: ['source'],
 			},
 		});
 		const notMatchTransformer = createContract<TransformerType>({
@@ -37,10 +22,10 @@ describe('Transformers', function () {
 			version: randomUUID(),
 			typeVersion: '1.0.0',
 			data: {
-				autoFinalize: false,
-				filter: filterNotEqualsInput,
+				transforms: ['else'],
 			},
 		});
+
 		const input = createContract({
 			type: 'source',
 			name: 'test',

--- a/test/unit/task.spec.ts
+++ b/test/unit/task.spec.ts
@@ -8,7 +8,9 @@ describe('Tasks', function () {
 			loop: 'test',
 			version: '1.0.0',
 			typeVersion: '1.0.0',
-			data: { filter: {}, autoFinalize: true },
+			data: {
+				transforms: [],
+			},
 		});
 		const input = createContract({
 			type: 'source',


### PR DESCRIPTION
This removes the JSON schema filter for transfomers contracts and instead uses a list of types that
the transformer acts on.

Change-type: major
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>