### PR TITLE
Exports js-yaml as yaml.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,3 +10,4 @@ export * from './runtime';
 export * from './task';
 export * from './transformer';
 export * from './workspace';
+export * as yaml from 'js-yaml';


### PR DESCRIPTION
This gives transformers tools to read/write yaml files without including additional yaml packages.  The `index.ts` file injected by the transformer-bundle transformer needs `js-yaml` as part of the dependencies. By exporting `yaml` as part of transformers-core, engineers would only need to include `transformers-core` as the bundle's dependency.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>